### PR TITLE
Fix typos in hello scenario

### DIFF
--- a/hello/step2.md
+++ b/hello/step2.md
@@ -51,7 +51,7 @@ The *name* is the name of the image - in our case we have used `hello`.
 
 The *image digest* is a hash of the image contents, and it's an immutable identifier for that exact version of the image. If you rebuild the image, it will have a different hash.
 
-The *image digest* and the *tag* are both ways of identifying versions of the same image. The digest is unique to the particular image, but you can give any image any tag you like. The same tag might be re-used to refer to different versions of the image. In addition, a given image can have any unmber of different tags. 
+The *image digest* and the *tag* are both ways of identifying versions of the same image. The digest is unique to the particular image, but you can give any image any tag you like. The same tag might be re-used to refer to different versions of the image. In addition, a given image can have any number of different tags. 
 
 In practice, tags are often used to hold the semantic version numbers. For example, if the most recent version of a particular component is version 2.1.3, the same image might have tags "2", "2.1", "2.1.3" and "latest". If someone pulls a version without specifying the tag, they will get this version because the tag defaults to "latest".
 

--- a/hello/step4.md
+++ b/hello/step4.md
@@ -52,4 +52,4 @@ The output from the `docker ps` command shows you the host port number that has 
 
 ## Next step
 
-In this example you needed to know what port the containerized app is using, so that you can specify it on the `-p` parameter to the `docker run` command. In the next step you'll see how you can specify the container port number in the Dockerfile, so that this information is built into the container image andyou don't need to know it at runtime.
+In this example you needed to know what port the containerized app is using, so that you can specify it on the `-p` parameter to the `docker run` command. In the next step you'll see how you can specify the container port number in the Dockerfile, so that this information is built into the container image and you don't need to know it at runtime.


### PR DESCRIPTION
Really cool scenario with nice side notes and links to further readings.

WDYT about adding the following explanations which were not obvious for me event after using Docker for quite some time.

## UNDERSTANDING `ENTRYPOINT` AND `CMD`
In a `Dockerfile`, two instructions define the two parts:

* `ENTRYPOINT` defines the executable invoked when the container is started.
* `CMD` specifies the arguments that get passed to the `ENTRYPOINT`.

Although you can use the `CMD` instruction to specify the command you want to execute when the image is run, the correct way is to do it through the `ENTRYPOINT` instruction and to only specify the `CMD` if you want to define the default arguments. The image can then be run without specifying any arguments.

## UNDERSTANDING THE DIFFERENCE BETWEEN THE SHELL AND EXEC FORMS
Both instructions support two different forms:

* shell form -- For example, `ENTRYPOINT hello`
* exec form -- For example, `ENTRYPOINT ["hello"]`

The difference is whether the specified command is invoked inside a shell or not.